### PR TITLE
Remove dependency on Commerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,11 @@ public class ImageFile : ImageData
 The hotspot editor should now be visible on a tab named 'Hotspots' when editing 'All properties' on an image inside EPiServer edit mode.
 The hotspot data saved during edit is then persisted into the property defined above.
 
+If you want to link to other content than the default of Commerce you can specify content like the following.
+'''
+    [Roots(RootSelection.StartPage | RootSelection.CommerceRootPage)]
+    [Types(typeof(PageData), typeof(ProductContent))]
+''''
+
 ## Changelog
 [Changelog](CHANGELOG.md)

--- a/src/Geta.EPi.HotspotsEditor/ClientResources/Scripts/Editors/HotspotsEditor.js
+++ b/src/Geta.EPi.HotspotsEditor/ClientResources/Scripts/Editors/HotspotsEditor.js
@@ -1,162 +1,153 @@
 ﻿define([
     "dojo/_base/declare",
+    "dojo/_base/lang",
     "dijit/_WidgetBase",
     "dijit/_TemplatedMixin",
     "epi-cms/_ContentContextMixin",
     "epi-cms/widget/ContentSelector",
+    "epi/i18n!epi/cms/nls/geta.clientresources.hotspotseditor",
+    "epi/i18n!epi/cms/nls/shell.cms.externallinks.details",
     'dojo/text!./Templates/HotspotsEditor.html'
-], function (declare, _WidgetBase, _TemplatedMixin, _ContentContextMixin, ContentSelector, template) {
-
+], function (declare, lang, _WidgetBase, _TemplatedMixin, _ContentContextMixin, ContentSelector, localizations, externallinksResources, template) {
     return declare("hotspots/editors/HotspotsEditor",
         [_WidgetBase, _TemplatedMixin, _ContentContextMixin], {
-            templateString: template,
+        templateString: template,
 
-            //********************************************************************************
-            //*PROTOTYPE/PUBLIC FUNCTIONS*****************************************************
-            //********************************************************************************
+        _resources: lang.mixin(localizations, externallinksResources),
 
-            postCreate: function () {
+        //********************************************************************************
+        //*PROTOTYPE/PUBLIC FUNCTIONS*****************************************************
+        //********************************************************************************
 
-                this.set('value', this.value);
+        postCreate: function () {
+            this.set('value', this.value);
 
-                this.activeHotSpot = undefined;
+            this.activeHotSpot = undefined;
 
-                this.HotSpotsEditor = new Oxx.HotSpotsEditor(this.domNode);
-                this.HotSpotsEditor.setValue(this.value);
+            this.HotSpotsEditor = new Oxx.HotSpotsEditor(this.domNode);
+            this.HotSpotsEditor.setValue(this.value);
 
+            this._attachEventListeners();
+        },
 
-                this._attachEventListeners();
+        //********************************************************************************
+        //*PRIVATE OBJECT METHODS ********************************************************
+        //********************************************************************************
 
-            },
+        /**
+        * Attach events here
+        *
+        * @private
+        */
+        _attachEventListeners: function () {
+            jQuery(this.HotSpotsEditor).on('change', jQuery.proxy(this._onChange, this));
+            jQuery(this.HotSpotsEditor).on('select', jQuery.proxy(this._onHotSpotSelected, this));
+            jQuery(this.HotSpotsEditor).on('deselect', jQuery.proxy(this._onHotSpotDeSelected, this));
+        },
 
-            //********************************************************************************
-            //*PRIVATE OBJECT METHODS ********************************************************
-            //********************************************************************************
+        //********************************************************************************
 
-            /**
-            * Attach events here
-            *
+        /**
+         * Recreates the product selector with an initial value so that we don't trigger
+         * the change event
+         *
+         * @param value
+         * @private
+         */
+        _createProductSelector: function (value) {
+            $(this.linkToProduct).empty();
+
+            this.productSelector = new ContentSelector({
+                value: value,
+                cultureSpecific: false,
+                allowedTypes: this.allowedTypes != null ? this.allowedTypes : ["episerver.core.icontentdata"],
+                roots: this.roots != null ? this.roots : ["-1073741823__CatalogContent"],
+                label: this._resources.content,
+                allowedDndTypes: this.allowedDndTypes != null ? this.allowedDndTypes : ["episerver.core.icontentdata.reference"]
+            });
+
+            $(this.linkToProduct).append(this.productSelector.domNode);
+
+            this.productSelector.on('change', jQuery.proxy(this._onLinkToProductChange, this));
+        },
+
+        //********************************************************************************
+
+        /**
+            * Called on init to load the value from database and set on the control
+            * @param value
             * @private
             */
-            _attachEventListeners: function () {
-                jQuery(this.HotSpotsEditor).on('change', jQuery.proxy(this._onChange, this));
-                jQuery(this.HotSpotsEditor).on('select', jQuery.proxy(this._onHotSpotSelected, this));
-                jQuery(this.HotSpotsEditor).on('deselect', jQuery.proxy(this._onHotSpotDeSelected, this));
+        _setValueAttr: function (value) {
+            this.hotspots = value;
+            this._set('value', value);
 
-            },
+            if (!this.HotSpotsEditor) return;
+            this.HotSpotsEditor.setValue(value);
+        },
 
-            //********************************************************************************
+        //********************************************************************************
+        //*EVENT METHODS******************************************************************
+        //********************************************************************************
 
-		    /**
-			 * Recreates the product selector with an initial value so that we don't trigger
-			 * the change event
-			 *
-			 * @param value
-			 * @private
-			 */
-            _createProductSelector: function (value) {
-
-                $(this.linkToProduct).empty();
-
-                this.productSelector = new ContentSelector({
-                    value: value,
-                    cultureSpecific: false,
-                    allowedTypes: ["episerver.core.icontentdata"],
-                    roots: ["-1073741823__CatalogContent"],
-                    label: 'Select product',
-                    allowedDndTypes: ["episerver.core.icontentdata.reference"]
-                });
-
-                $(this.linkToProduct).append(this.productSelector.domNode);
-
-                this.productSelector.on('change', jQuery.proxy(this._onLinkToProductChange, this));
-            },
-
-            //********************************************************************************
-
-            /**
-	            * Called on init to load the value from database and set on the control
-	            * @param value
-	            * @private
-	            */
-            _setValueAttr: function (value) {
-                this.hotspots = value;
+        /**
+        * When any HotSpots are modified, save the changes
+        * @param event
+        * @private
+        */
+        _onChange: function (event) {
+            var value = event.target.getValue();
+            if (this.value !== value) {
+                // this will trigger the save event on object, giving the option to publish the content
+                this.parent.editing = true;
                 this._set('value', value);
+                this.onChange(value);
 
-                if (!this.HotSpotsEditor) return;
-                this.HotSpotsEditor.setValue(value);
-            },
-
-            //********************************************************************************
-            //*EVENT METHODS******************************************************************
-            //********************************************************************************
-
-            /**
-            * When any HotSpots are modified, save the changes
-            * @param event
-            * @private
-            */
-            _onChange: function (event) {
-                var value = event.target.getValue();
-                //window.console.log('change event: ', this.value !== value, this.value, value);
-                if (this.value !== value) {
-
-                    // this will trigger the save event on object, giving the option to publish the content
-                    this.parent.editing = true;
-                    this._set('value', value);
-                    this.onChange(value);
-
-                    this.parent.editing = false;
-                }
-            },
-
-            //********************************************************************************
-
-		    /**
-			 * Updates the value of the linkToProduct control when a HotSpot is selected
-			 *
-			 * @param event
-			 * @param hotSpot
-			 * @private
-			 */
-            _onHotSpotSelected: function (event, hotSpot) {
-
-                this.activeHotSpot = hotSpot;
-
-                var link = this.activeHotSpot.getLink();
-
-                this._createProductSelector(link);
-
-            },
-
-            //********************************************************************************
-
-		    /**
-			 *
-			 * @param event
-			 * @private
-			 */
-            _onHotSpotDeSelected: function (event) {
-                this.activeHotSpot = undefined;
-            },
-
-            //********************************************************************************
-
-		    /**
-			 * When a product is selected or deselected update the product link on the HotSpot
-			 *
-			 * @param event
-			 * @private
-			 */
-            _onLinkToProductChange: function (event) {
-
-                if (this.activeHotSpot) {
-                    this.activeHotSpot.setLink(this.productSelector.value);
-                    this.activeHotSpot.saveChanges();
-                }
-
+                this.parent.editing = false;
             }
+        },
 
+        //********************************************************************************
 
-        });
+        /**
+         * Updates the value of the linkToProduct control when a HotSpot is selected
+         *
+         * @param event
+         * @param hotSpot
+         * @private
+         */
+        _onHotSpotSelected: function (event, hotSpot) {
+            this.activeHotSpot = hotSpot;
+
+            var link = this.activeHotSpot.getLink();
+
+            this._createProductSelector(link);
+        },
+
+        //********************************************************************************
+
+        /**
+         *
+         * @param event
+         * @private
+         */
+        _onHotSpotDeSelected: function (event) {
+            this.activeHotSpot = undefined;
+        },
+
+        //********************************************************************************
+
+        /**
+         * When a product is selected or deselected update the product link on the HotSpot
+         *
+         * @param event
+         * @private
+         */
+        _onLinkToProductChange: function (event) {
+            if (this.activeHotSpot) {
+                this.activeHotSpot.setLink(this.productSelector.value);
+                this.activeHotSpot.saveChanges();
+            }
+        }
+    });
 });

--- a/src/Geta.EPi.HotspotsEditor/ClientResources/Scripts/Editors/Templates/HotspotsEditor.html
+++ b/src/Geta.EPi.HotspotsEditor/ClientResources/Scripts/Editors/Templates/HotspotsEditor.html
@@ -1,17 +1,19 @@
-﻿<div class="hotspotseditor-wrapper">
+﻿﻿<div class="hotspotseditor-wrapper">
     <div class="hotspotseditor">
         <input type="hidden" class="value" data-dojo-attach-point="hotspots" />
 
         <div class="epi-gadgetInnerToolbar">
             <div class="toolbar">
-                <span class="new hotspot" title="@Model.NewHotSpotText">New</span>
-                <span class="trash" title="@Model.DeleteHotSpotText">
+                <span class="new hotspot" title="${_resources.new}">
+                    ${_resources.new}
+                </span>
+                <span class="trash" title="${_resources.dragheretodelete}">
                     <span class="icon epi-iconTrash"></span>
-                    Drag here to delete
+                    ${_resources.dragheretodelete}
                 </span>
                 <span class="link-to-product hidden">
                     <span class="icon epi-iconReferences"></span>
-                    Link to product
+                    ${_resources.content}
                     <span class="control hidden" data-dojo-attach-point="linkToProduct"></span>
                 </span>
             </div>

--- a/src/Geta.EPi.HotspotsEditor/Cms/Attributes/RootsAttribute.cs
+++ b/src/Geta.EPi.HotspotsEditor/Cms/Attributes/RootsAttribute.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using EPiServer.Core;
+using Geta.EPi.HotspotsEditor.Cms.Models;
+
+namespace Geta.EPi.HotspotsEditor.Cms.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class RootsAttribute : Attribute
+    {
+        public RootsAttribute() : this(RootSelection.CommerceRootPage)
+        {
+        }
+
+        public RootsAttribute(RootSelection selectedRoots)
+        {
+            SelectedRoots = selectedRoots;
+        }
+
+        public RootSelection SelectedRoots { get; set; }
+
+        public IEnumerable<ContentReference> Roots
+        {
+            get
+            {
+                if (SelectedRoots.HasFlag(RootSelection.RootPage))
+                    yield return ContentReference.RootPage;
+                if (SelectedRoots.HasFlag(RootSelection.StartPage))
+                    yield return ContentReference.StartPage;
+                if (SelectedRoots.HasFlag(RootSelection.CommerceRootPage))
+                    yield return new ContentReference(1 | 3 << 30, 0, "CatalogContent");
+            }
+        }
+    }
+}

--- a/src/Geta.EPi.HotspotsEditor/Cms/Attributes/TypesAttribute.cs
+++ b/src/Geta.EPi.HotspotsEditor/Cms/Attributes/TypesAttribute.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using EPiServer.Core;
+
+namespace Geta.EPi.HotspotsEditor.Cms.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class TypesAttribute : Attribute
+    {
+        public Type[] AllowedTypes { get; set; }
+
+        public string TypesFormatSuffix { get; set; }
+
+        public TypesAttribute()
+            : this(new[] { typeof(IContentData) }, "reference")
+        {
+        }
+
+        public TypesAttribute(params Type[] allowedTypes) : this(allowedTypes, null)
+        {
+        }
+
+        public TypesAttribute(Type[] allowedTypes, string typesFormatSuffix = null)
+        {
+            AllowedTypes = allowedTypes;
+            TypesFormatSuffix = typesFormatSuffix;
+        }
+    }
+}

--- a/src/Geta.EPi.HotspotsEditor/Cms/EditorDescriptors/HotspotsEditorDescriptor.cs
+++ b/src/Geta.EPi.HotspotsEditor/Cms/EditorDescriptors/HotspotsEditorDescriptor.cs
@@ -1,5 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using EPiServer.Cms.Shell.UI.ObjectEditing;
+using EPiServer.Shell.ObjectEditing;
 using EPiServer.Shell.ObjectEditing.EditorDescriptors;
+using Geta.EPi.HotspotsEditor.Cms.Attributes;
 using Geta.EPi.HotspotsEditor.Cms.Models;
 
 namespace Geta.EPi.HotspotsEditor.Cms.EditorDescriptors
@@ -7,9 +12,28 @@ namespace Geta.EPi.HotspotsEditor.Cms.EditorDescriptors
     [EditorDescriptorRegistration(TargetType = typeof(IEnumerable<HotSpotContainer>), UIHint = UIHint.HotspotsEditor)]
     public class HotspotsEditorDescriptor : EditorDescriptor
     {
-        public HotspotsEditorDescriptor()
+        private readonly AllowedTypesMetadataExtender _allowedTypesMetadataExtender;
+
+        public HotspotsEditorDescriptor(AllowedTypesMetadataExtender allowedTypesMetadataExtender)
         {
             ClientEditingClass = "hotspots/editors/HotspotsEditor";
+            this._allowedTypesMetadataExtender = allowedTypesMetadataExtender;
+        }
+
+        public override void ModifyMetadata(ExtendedMetadata metadata, IEnumerable<Attribute> attributes)
+        {
+            if (attributes?.OfType<TypesAttribute>().FirstOrDefault() is TypesAttribute typesAttribute && metadata.Parent is ExtendedMetadata parent)
+            {
+                AllowedTypes = typesAttribute.AllowedTypes;
+                AllowedTypesFormatSuffix = typesAttribute.TypesFormatSuffix;
+            }
+
+            if (attributes?.OfType<RootsAttribute>().FirstOrDefault() is RootsAttribute rootsAttribute)
+            {
+                metadata.EditorConfiguration["roots"] = rootsAttribute.Roots;
+            }
+
+            base.ModifyMetadata(metadata, attributes);
         }
     }
 }

--- a/src/Geta.EPi.HotspotsEditor/Cms/Models/HotSpotContainer.cs
+++ b/src/Geta.EPi.HotspotsEditor/Cms/Models/HotSpotContainer.cs
@@ -1,6 +1,4 @@
-using System.Web.UI.WebControls;
 using EPiServer;
-using EPiServer.Commerce.Catalog.ContentTypes;
 using EPiServer.Core;
 using EPiServer.ServiceLocation;
 using Newtonsoft.Json;
@@ -13,7 +11,7 @@ namespace Geta.EPi.HotspotsEditor.Cms.Models
         private IContent _content;
 
         public HotSpotContainer() : this(ServiceLocator.Current.GetInstance<IContentLoader>())
-        {}
+        { }
 
         public HotSpotContainer(IContentLoader contentLoader)
         {
@@ -22,57 +20,42 @@ namespace Geta.EPi.HotspotsEditor.Cms.Models
 
         public string Link { get; set; }
 
-        private void LoadContent()
-        {
-            if (!string.IsNullOrEmpty(Link) && _content == null)
-            {
-                ContentReference.TryParse(Link, out ContentReference contentReference);
-                _contentLoader.TryGet(contentReference, out _content);
-            }
-        }
-
         [JsonIgnore]
-        public EntryContentBase IndexedProduct
-        {
-            get
-            {                
-                ContentReference.TryParse(Link, out ContentReference contentReference);
-                _contentLoader.TryGet(contentReference, out EntryContentBase entryBase);
-
-                return entryBase;
-            }
-        }
-
-        [JsonIgnore]
-        public string ProductCode
+        public IContent Content
         {
             get
             {
-                ContentReference.TryParse(Link, out ContentReference contentReference);
-                _contentLoader.TryGet(contentReference, out EntryContentBase product);
-
-                if (product == null) return string.Empty;
-
-                return product.Code;
+                if (_content == null && !string.IsNullOrEmpty(Link) && _content == null && ContentReference.TryParse(Link, out ContentReference contentReference))
+                {
+                    _contentLoader.TryGet(contentReference, out _content);
+                }
+                return _content;
             }
         }
 
         public Rectangle HotSpot { get; set; }
+
         public FRectangle Area { get; set; }
 
         public class Rectangle
         {
             public decimal Top { get; set; }
+
             public decimal Left { get; set; }
+
             public int Width { get; set; }
+
             public int Height { get; set; }
         }
 
         public class FRectangle
         {
             public decimal Top { get; set; }
+
             public decimal Left { get; set; }
+
             public decimal Width { get; set; }
+
             public decimal Height { get; set; }
         }
     }

--- a/src/Geta.EPi.HotspotsEditor/Cms/Models/RootSelection.cs
+++ b/src/Geta.EPi.HotspotsEditor/Cms/Models/RootSelection.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Geta.EPi.HotspotsEditor.Cms.Models
+{
+    [Flags]
+    public enum RootSelection
+    {
+        None = 0,
+        RootPage = 1,
+        StartPage = 1 << 1,
+        CommerceRootPage = 1 << 2,
+        All = RootPage | StartPage | CommerceRootPage,
+    }
+}

--- a/src/Geta.EPi.HotspotsEditor/Geta.EPi.HotspotsEditor.csproj
+++ b/src/Geta.EPi.HotspotsEditor/Geta.EPi.HotspotsEditor.csproj
@@ -30,10 +30,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AjaxControlToolkit, Version=3.0.30930.28736, Culture=neutral, PublicKeyToken=28f01b0e84b6d53e, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\AjaxControlToolkit.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
     <Reference Include="AuthorizeNet, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\AuthorizeNet.1.9.4\lib\AuthorizeNet.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
@@ -54,24 +50,12 @@
       <HintPath>..\..\packages\EPiServer.Framework.11.11.1\lib\net461\EPiServer.ApplicationModules.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="EPiServer.Business.Commerce, Version=13.0.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\EPiServer.Business.Commerce.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
     <Reference Include="EPiServer.Cms.AspNet, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.11.1\lib\net461\EPiServer.Cms.AspNet.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="EPiServer.Cms.Shell.UI, Version=11.1.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EPiServer.CMS.UI.Core.11.1.0\lib\net461\EPiServer.Cms.Shell.UI.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="EPiServer.Commerce.Internal.Migration, Version=13.0.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\EPiServer.Commerce.Internal.Migration.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="EPiServer.Commerce.Reporting, Version=13.0.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\EPiServer.Commerce.Reporting.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="EPiServer.Configuration, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
@@ -136,66 +120,6 @@
     </Reference>
     <Reference Include="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="Mediachase.BusinessFoundation, Version=13.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.BusinessFoundation.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="Mediachase.BusinessFoundation.Data, Version=13.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.BusinessFoundation.Data.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="Mediachase.Commerce, Version=13.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Commerce.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="Mediachase.Commerce.Plugins.Payment, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Commerce.Plugins.Payment.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="Mediachase.Commerce.Plugins.Shipping, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Commerce.Plugins.Shipping.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="Mediachase.Commerce.Website, Version=13.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Commerce.Website.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="Mediachase.Commerce.Workflow, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Commerce.Workflow.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="Mediachase.DataProvider, Version=13.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.DataProvider.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="Mediachase.FileUploader, Version=13.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.FileUploader.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="Mediachase.MetaDataPlus, Version=13.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.MetaDataPlus.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="Mediachase.Search, Version=13.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Search.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="Mediachase.Search.Extensions, Version=13.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Search.Extensions.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="Mediachase.Search.LuceneSearchProvider, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Search.LuceneSearchProvider.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="Mediachase.SqlDataProvider, Version=13.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.SqlDataProvider.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="Mediachase.WebConsoleLib, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.WebConsoleLib.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -286,8 +210,11 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Cms\Attributes\RootsAttribute.cs" />
+    <Compile Include="Cms\Attributes\TypesAttribute.cs" />
     <Compile Include="Cms\EditorDescriptors\HotspotsEditorDescriptor.cs" />
     <Compile Include="Cms\Models\HotSpotContainer.cs" />
+    <Compile Include="Cms\Models\RootSelection.cs" />
     <Compile Include="Cms\Properties\PropertyHotspotContainerList.cs" />
     <Compile Include="Cms\Properties\PropertyJsonSerializedObject.cs" />
     <Compile Include="Cms\UIHint.cs" />
@@ -342,6 +269,7 @@
     <Content Include="ClientResources\Styles\Jqueryui\images\ui-icons_cd0a0a_256x240.png" />
     <Content Include="ClientResources\Styles\Jqueryui\jquery-ui-1.10.4.custom.css" />
     <Content Include="ClientResources\Styles\Jqueryui\jquery-ui-1.10.4.custom.min.css" />
+    <EmbeddedResource Include="lang\ClientResources.xml" />
     <Content Include="readme.txt" />
   </ItemGroup>
   <ItemGroup />

--- a/src/Geta.EPi.HotspotsEditor/lang/ClientResources.xml
+++ b/src/Geta.EPi.HotspotsEditor/lang/ClientResources.xml
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<languages>
+  <language name="English" id="en">
+    <geta>
+      <clientresources>
+        <hotspotseditor>
+          <dragheretodelete>Drag here to delete</dragheretodelete>
+          <new>New</new>
+        </hotspotseditor>
+      </clientresources>
+    </geta>
+  </language>
+  <language name="Danish" id="da">
+    <geta>
+      <clientresources>
+        <hotspotseditor>
+          <dragheretodelete>Træk her for at slette</dragheretodelete>
+          <new>Ny</new>
+        </hotspotseditor>
+      </clientresources>
+    </geta>
+  </language>
+  <language name="German" id="de">
+    <geta>
+      <clientresources>
+        <hotspotseditor>
+          <dragheretodelete>Zum Löschen hierher ziehen</dragheretodelete>
+          <new>Neu</new>
+        </hotspotseditor>
+      </clientresources>
+    </geta>
+  </language>
+  <language name="Spanish" id="es">
+    <geta>
+      <clientresources>
+        <hotspotseditor>
+          <dragheretodelete>Arrastra aquí para borrar</dragheretodelete>
+          <new>Nuevo</new>
+        </hotspotseditor>
+      </clientresources>
+    </geta>
+  </language>
+  <language name="Finnish" id="fi">
+    <geta>
+      <clientresources>
+        <hotspotseditor>
+          <dragheretodelete>Poista vetämällä tästä</dragheretodelete>
+          <new>Uusi</new>
+        </hotspotseditor>
+      </clientresources>
+    </geta>
+  </language>
+  <language name="French" id="fr">
+    <geta>
+      <clientresources>
+        <hotspotseditor>
+          <dragheretodelete>Faites glisser ici pour supprimer</dragheretodelete>
+          <new>Nouveau</new>
+        </hotspotseditor>
+      </clientresources>
+    </geta>
+  </language>
+  <language name="Italiano" id="it">
+    <geta>
+      <clientresources>
+        <hotspotseditor>
+          <dragheretodelete>Trascina qui per eliminare</dragheretodelete>
+          <new>Nuovo</new>
+        </hotspotseditor>
+      </clientresources>
+    </geta>
+  </language>
+  <language name="日本語 (Japanese)" id="ja">
+    <geta>
+      <clientresources>
+        <hotspotseditor>
+          <dragheretodelete>ここにドラッグして削除します</dragheretodelete>
+          <new>新着</new>
+        </hotspotseditor>
+      </clientresources>
+    </geta>
+  </language>
+  <language name="Dutch" id="nl">
+    <geta>
+      <clientresources>
+        <hotspotseditor>
+          <dragheretodelete>Sleep hier om te verwijderen</dragheretodelete>
+          <new>Nieuwe</new>
+        </hotspotseditor>
+      </clientresources>
+    </geta>
+  </language>
+  <language name="Norwegian" id="no">
+    <geta>
+      <clientresources>
+        <hotspotseditor>
+          <dragheretodelete>Dra hit for å slette</dragheretodelete>
+          <new>Ny</new>
+        </hotspotseditor>
+      </clientresources>
+    </geta>
+  </language>
+  <language name="Swedish" id="sv">
+    <geta>
+      <clientresources>
+        <hotspotseditor>
+          <dragheretodelete>Dra hit för att ta bort</dragheretodelete>
+          <new>Ny</new>
+        </hotspotseditor>
+      </clientresources>
+    </geta>
+  </language>
+  <language name="Chinese (Simplified, PRC)" id="zh-CN">
+    <geta>
+      <clientresources>
+        <hotspotseditor>
+          <dragheretodelete>拖到此处即可删除</dragheretodelete>
+          <new>新的</new>
+        </hotspotseditor>
+      </clientresources>
+    </geta>
+  </language>
+</languages>

--- a/src/Geta.EPi.HotspotsEditor/packages.config
+++ b/src/Geta.EPi.HotspotsEditor/packages.config
@@ -6,7 +6,6 @@
   <package id="EPiServer.CMS.AspNet" version="11.11.1" targetFramework="net461" />
   <package id="EPiServer.CMS.Core" version="11.11.1" targetFramework="net461" />
   <package id="EPiServer.CMS.UI.Core" version="11.1.0" targetFramework="net461" />
-  <package id="EPiServer.Commerce.Core" version="13.0.0" allowedVersions="[13,14)" targetFramework="net461" />
   <package id="EPiServer.Framework" version="11.11.1" targetFramework="net461" />
   <package id="EPiServer.Framework.AspNet" version="11.11.1" targetFramework="net461" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net461" />


### PR DESCRIPTION
A colleague of mine needed #9 fixed for a project still running EPi 11 / 4.8

So handpicked the changes from #13, more precisely:

* Allow to modify allowedtypes / roots, remove dependency on commerce
* Localization

Currently don't have a installation to test it against but should be working.

There are several vulnerable packages that need a bump, but there are separate automatic prs for that.